### PR TITLE
docs: add MCP usage guide to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,28 @@ claude mcp add vecgrep -- uvx vecgrep
 
 `uvx` downloads and runs VecGrep in an isolated environment on first use — no cloning or manual setup required.
 
+## Usage with Claude
+
+You don't trigger VecGrep manually - Claude decides when to call the tools based on what you ask.
+
+| What you say to Claude | Tool invoked |
+|---|---|
+| "Index my project at /Users/me/myapp" | `index_codebase` |
+| "How does authentication work in this codebase?" | `search_code` |
+| "Find where database connections are set up" | `search_code` |
+| "How many files are indexed?" | `get_index_status` |
+
+**Typical first-time flow:**
+
+```
+You:    "Search for how payments are handled in /Users/me/myapp"
+Claude: [calls index_codebase automatically since no index exists]
+Claude: [calls search_code with your query]
+Claude: "Here's how payments work — in src/payments.py:42..."
+```
+
+After the first index, subsequent searches skip unchanged files automatically — no re-indexing needed unless your code changes.
+
 ## Tools
 
 ### `index_codebase(path, force=False)`


### PR DESCRIPTION
**Type of change** (choose one or more):
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation update
- [ ] Chore (e.g., build process, CI/CD, dependency updates)
- [ ] Test improvement

**Description**
Adds a new **Usage with Claude** section to the README explaining how VecGrep works once installed as an MCP plugin. Users currently have no guidance on how to trigger the tools or what to say to Claude to get results.

The section covers:
- How Claude auto-invokes tools based on natural language (no manual triggering)
- A table mapping example prompts to the tool each one calls
- The typical first-time index → search flow with a concrete example
- A note on incremental indexing behaviour

**Related Issues/PRs**
Closes #2

**Changes Made**
- Added `## Usage with Claude` section to `README.md` between the Claude Code integration section and the Tools section

**Testing**
- [x] Manual testing (describe steps)
  - Verified README renders correctly on GitHub
  - Confirmed section placement and content accuracy

**Checklist**
- [x] My code follows the project's style guidelines.
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.