### PR TITLE
docs: update install instructions to use uv tool install --python 3.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,13 @@ Incremental re-indexing via SHA256 file hashing skips unchanged files.
 
 ## Installation
 
-Requires Python 3.12+ and [uv](https://docs.astral.sh/uv/).
+Requires Python 3.12 and [uv](https://docs.astral.sh/uv/).
+
+> **Note:** Python 3.12 is required — `tree-sitter-languages` does not yet have wheels for Python 3.13+.
 
 ```bash
-pip install vecgrep        # standard pip
-uv tool install vecgrep   # uv tool (isolated, recommended)
+pip install vecgrep                        # standard pip
+uv tool install --python 3.12 vecgrep     # uv tool (recommended)
 ```
 
 ## Claude Code integration
@@ -34,14 +36,11 @@ uv tool install vecgrep   # uv tool (isolated, recommended)
 Run once — works for every project:
 
 ```bash
-claude mcp add --scope user vecgrep -- uvx --python 3.12 vecgrep
+uv tool install --python 3.12 vecgrep
+claude mcp add --scope user vecgrep -- vecgrep
 ```
 
-This registers VecGrep in your user config (`~/.claude.json`) so it's available globally across all projects without any per-project setup.
-
-> **Note:** `--python 3.12` is required because `tree-sitter-languages` does not yet have wheels for Python 3.13+. VecGrep requires Python 3.12.
-
-`uvx` downloads and runs VecGrep in an isolated environment on first use — no cloning or manual setup required.
+This installs VecGrep as a persistent binary and registers it in your user config (`~/.claude.json`) so it's available globally across all projects. Starts instantly — no download delay on Claude Code launch.
 
 ## Usage with Claude
 


### PR DESCRIPTION
**Type of change** (choose one or more):
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation update
- [ ] Chore (e.g., build process, CI/CD, dependency updates)
- [ ] Test improvement

**Description**
`uv tool install vecgrep` fails on Python 3.13+ because `tree-sitter-languages` has no wheels for those versions. The previous README also used `uvx` for MCP setup which causes a cold-start download delay every time Claude Code launches.

This PR updates the install and MCP setup instructions to:
- Use `uv tool install --python 3.12 vecgrep` to install as a persistent binary
- Use the installed `vecgrep` binary directly in the MCP config (instant startup, no delay)
- Add a clear note at the top of Installation that Python 3.12 is required

**Related Issues/PRs**
Closes #6

**Changes Made**
- Updated `## Installation` section with `--python 3.12` flag and Python version note
- Updated `## Claude Code integration` to use the 2-step permanent install approach

**Testing**
- [x] Manual testing (describe steps)
  - Verified `uv tool install --python 3.12 vecgrep` installs successfully
  - Verified `claude mcp add --scope user vecgrep -- vecgrep` works and starts instantly

**Checklist**
- [x] My code follows the project's style guidelines.
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.