### PR TITLE
docs: add GitHub Discussion templates and community section

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/ideas.yml
+++ b/.github/DISCUSSION_TEMPLATE/ideas.yml
@@ -1,0 +1,51 @@
+title: "[Idea] "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Have an idea to make VecGrep better? Share it here before opening a PR so we can discuss the approach.
+
+  - type: input
+    id: title
+    attributes:
+      label: Idea summary
+      placeholder: e.g. "Support indexing remote GitHub repos"
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: Describe the pain point or limitation you're hitting.
+      placeholder: e.g. "I want to search a repo I don't have locally without cloning it first."
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: How would you like this to work? Don't worry about implementation details.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any other approaches you thought about?
+    validations:
+      required: false
+
+  - type: dropdown
+    id: willing
+    attributes:
+      label: Would you be willing to contribute this?
+      options:
+        - "Yes — I'd like to open a PR"
+        - "Maybe — if someone guides me"
+        - "No — just sharing the idea"
+    validations:
+      required: true

--- a/.github/DISCUSSION_TEMPLATE/q-and-a.yml
+++ b/.github/DISCUSSION_TEMPLATE/q-and-a.yml
@@ -1,0 +1,35 @@
+title: "[Q&A] "
+labels: ["question"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Got a question about VecGrep? Ask away — no question is too simple.
+
+  - type: input
+    id: summary
+    attributes:
+      label: What's your question?
+      placeholder: e.g. "How do I index a monorepo with multiple projects?"
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: Any setup details that might help — OS, Python version, project size, error messages etc.
+      placeholder: |
+        - OS: macOS 14
+        - Python: 3.12
+        - Project size: ~500 files
+    validations:
+      required: false
+
+  - type: textarea
+    id: tried
+    attributes:
+      label: What have you tried?
+      description: Steps or commands you've already attempted.
+    validations:
+      required: false

--- a/.github/DISCUSSION_TEMPLATE/show-and-tell.yml
+++ b/.github/DISCUSSION_TEMPLATE/show-and-tell.yml
@@ -1,0 +1,39 @@
+title: "[Show & Tell] "
+labels: ["showcase"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Using VecGrep in an interesting way? Share it here — workflows, integrations, benchmarks, anything goes.
+
+  - type: input
+    id: title
+    attributes:
+      label: What are you sharing?
+      placeholder: e.g. "How I use VecGrep + claude-mem to onboard into new codebases"
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Tell us about it
+      description: Describe your setup, workflow, or findings. Screenshots and code snippets welcome.
+    validations:
+      required: true
+
+  - type: input
+    id: project_size
+    attributes:
+      label: Project size (optional)
+      placeholder: e.g. "~1,200 files, 180k lines of Python"
+    validations:
+      required: false
+
+  - type: textarea
+    id: token_savings
+    attributes:
+      label: Token savings or other results (optional)
+      description: Did you measure any improvements? Share the numbers.
+    validations:
+      required: false

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![CI](https://github.com/iamvirul/VecGrep/actions/workflows/ci.yml/badge.svg)](https://github.com/iamvirul/VecGrep/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/iamvirul/VecGrep/branch/main/graph/badge.svg)](https://codecov.io/gh/iamvirul/VecGrep)
+[![Discussions](https://img.shields.io/github/discussions/iamvirul/VecGrep)](https://github.com/iamvirul/VecGrep/discussions)
 
 Cursor-style semantic code search as an MCP plugin for Claude Code.
 
@@ -117,3 +118,12 @@ All other text files fall back to sliding-window line chunks.
 `~/.vecgrep/<sha256-of-project-path>/index.db`
 
 Each project gets its own isolated index. Delete the directory to wipe the index.
+
+## Community
+
+| | |
+|---|---|
+| ❓ **Questions** | [Start a Q&A discussion](https://github.com/iamvirul/VecGrep/discussions/new?category=q-a) |
+| 💡 **Ideas** | [Share an idea](https://github.com/iamvirul/VecGrep/discussions/new?category=ideas) |
+| 🚀 **Show & Tell** | [Share how you use VecGrep](https://github.com/iamvirul/VecGrep/discussions/new?category=show-and-tell) |
+| 🐛 **Bugs** | [Open an issue](https://github.com/iamvirul/VecGrep/issues/new) |


### PR DESCRIPTION
**Type of change** (choose one or more):
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation update
- [ ] Chore (e.g., build process, CI/CD, dependency updates)
- [ ] Test improvement

**Description**
Adds GitHub Discussion templates so users have a structured way to ask questions, share ideas, and show off their VecGrep workflows. Also adds a Discussions badge and a Community section to the README to surface these links.

**Related Issues/PRs**
Closes #12

**Changes Made**
- `.github/DISCUSSION_TEMPLATE/q-and-a.yml` — structured Q&A template with context and tried fields
- `.github/DISCUSSION_TEMPLATE/ideas.yml` — feature idea template with problem, proposal, and contribution willingness
- `.github/DISCUSSION_TEMPLATE/show-and-tell.yml` — showcase template for workflows, benchmarks, integrations
- `README.md` — added Discussions badge alongside CI and Codecov badges
- `README.md` — added Community section at the bottom with direct links to each discussion template

**Testing**
- [x] Manual testing (describe steps)
  - Verified all YAML files are valid
  - Verified README links point to correct discussion category URLs

**Checklist**
- [x] My code follows the project's style guidelines.
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.