### PR TITLE
chore: update repo URLs to VecGrep org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # VecGrep
 
-[![CI](https://github.com/iamvirul/VecGrep/actions/workflows/ci.yml/badge.svg)](https://github.com/iamvirul/VecGrep/actions/workflows/ci.yml)
-[![codecov](https://codecov.io/gh/iamvirul/VecGrep/branch/main/graph/badge.svg)](https://codecov.io/gh/iamvirul/VecGrep)
-[![Discussions](https://img.shields.io/github/discussions/iamvirul/VecGrep)](https://github.com/iamvirul/VecGrep/discussions)
+[![CI](https://github.com/VecGrep/VecGrep/actions/workflows/ci.yml/badge.svg)](https://github.com/VecGrep/VecGrep/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/VecGrep/VecGrep/branch/main/graph/badge.svg)](https://codecov.io/gh/VecGrep/VecGrep)
+[![Discussions](https://img.shields.io/github/discussions/VecGrep/VecGrep)](https://github.com/VecGrep/VecGrep/discussions)
 
 Cursor-style semantic code search as an MCP plugin for Claude Code.
 
@@ -162,7 +162,7 @@ The embedding model used by VecGrep is [`all-MiniLM-L6-v2-code-search-512`](http
 
 | | |
 |---|---|
-| ❓ **Questions** | [Start a Q&A discussion](https://github.com/iamvirul/VecGrep/discussions/new?category=q-a) |
-| 💡 **Ideas** | [Share an idea](https://github.com/iamvirul/VecGrep/discussions/new?category=ideas) |
-| 🚀 **Show & Tell** | [Share how you use VecGrep](https://github.com/iamvirul/VecGrep/discussions/new?category=show-and-tell) |
-| 🐛 **Bugs** | [Open an issue](https://github.com/iamvirul/VecGrep/issues/new) |
+| ❓ **Questions** | [Start a Q&A discussion](https://github.com/VecGrep/VecGrep/discussions/new?category=q-a) |
+| 💡 **Ideas** | [Share an idea](https://github.com/VecGrep/VecGrep/discussions/new?category=ideas) |
+| 🚀 **Show & Tell** | [Share how you use VecGrep](https://github.com/VecGrep/VecGrep/discussions/new?category=show-and-tell) |
+| 🐛 **Bugs** | [Open an issue](https://github.com/VecGrep/VecGrep/issues/new) |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,9 +26,9 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/iamvirul/VecGrep"
-Repository = "https://github.com/iamvirul/VecGrep"
-Issues = "https://github.com/iamvirul/VecGrep/issues"
+Homepage = "https://github.com/VecGrep/VecGrep"
+Repository = "https://github.com/VecGrep/VecGrep"
+Issues = "https://github.com/VecGrep/VecGrep/issues"
 
 [project.scripts]
 vecgrep = "vecgrep.server:main"


### PR DESCRIPTION
# Pull Request

## Type of Change
- [x] 🔧 Chore (build process, CI/CD, dependency updates)

## Description

Updates all hardcoded `iamvirul/VecGrep` URLs to `VecGrep/VecGrep` following the repository transfer to the VecGrep organization.

## Related Issues / PRs

N/A

## Changes Made

- `README.md` — updated all badge and link URLs to point to `VecGrep/VecGrep`
- `pyproject.toml` — updated `[project.urls]` (Homepage, Repository, Issues)

## Checklist
- [x] My code follows the project's style guidelines (`ruff` passes)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes