### PR TITLE
chore: add .githooks pre-commit lint check

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Pre-commit hook: lint check on staged Python files using ruff.
+#
+# Install once per clone:
+#   git config core.hooksPath .githooks
+
+set -euo pipefail
+
+STAGED=$(git diff --cached --name-only --diff-filter=ACM | grep '\.py$' || true)
+
+if [ -z "$STAGED" ]; then
+    exit 0
+fi
+
+echo "Running ruff lint check..."
+
+if command -v uv &>/dev/null; then
+    RUFF="uv run ruff"
+else
+    RUFF="ruff"
+fi
+
+if ! $RUFF check $STAGED; then
+    echo ""
+    echo "Lint check failed. Fix the issues above, re-stage the files, and commit again."
+    echo "To auto-fix:  $RUFF check --fix $STAGED"
+    exit 1
+fi
+
+echo "Lint check passed."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,10 +5,20 @@ Thanks for your interest in contributing!
 ## Getting Started
 
 ```bash
-git clone https://github.com/iamvirul/vecgrep
-cd vecgrep
-uv sync
+git clone https://github.com/VecGrep/VecGrep
+cd VecGrep
+uv sync --extra dev
 ```
+
+### Install the git hooks
+
+Run once after cloning to enable the pre-commit lint check:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+This runs `ruff` against staged Python files before every commit and blocks the commit if any violations are found.
 
 ## Development
 


### PR DESCRIPTION
# Pull Request

## Type of Change
- [x] 🔧 Chore (build process, CI/CD, dependency updates)
- [x] 📖 Documentation update

## Description

Adds a `.githooks/pre-commit` script that runs `ruff` against staged Python files before every commit. This gives contributors immediate lint feedback locally rather than waiting for CI.

The hook is opt-in — contributors activate it once per clone with:

```bash
git config core.hooksPath .githooks
```

## Related Issues / PRs

Closes #32

## Changes Made

- `.githooks/pre-commit` — pre-commit script that lints staged `.py` files with ruff; uses `uv run ruff` if uv is available, falls back to plain `ruff`
- `CONTRIBUTING.md` — added hook setup instructions; corrected clone URL to `VecGrep/VecGrep`; added `--extra dev` to `uv sync`

## Testing

- [x] Manual testing — staged a file with a lint violation, confirmed commit was blocked with the correct message
- [x] Staged a clean file, confirmed commit was allowed through

## Checklist
- [x] My code follows the project's style guidelines (`ruff` passes)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings