### PR TITLE
chore: release 1.5.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,59 @@ All notable changes to VecGrep are documented here.
 
 ---
 
+## [1.5.0] — 2026-02-28
+
+### Breaking Changes
+
+- **Store backend replaced**: SQLite + numpy vector store replaced with LanceDB.
+  Existing indexes at `~/.vecgrep/` must be re-indexed after upgrading —
+  simply run `index_codebase` again on your project.
+
+### Added
+
+**Performance**
+- **fastembed ONNX backend** — default embedding backend switched from
+  sentence-transformers (PyTorch) to fastembed (ONNX Runtime).
+  MCP server startup: ~6.6s → ~1.25s. First embed call: ~2–3s → ~100ms.
+- **IVF-PQ ANN index** — `build_index()` creates an approximate nearest
+  neighbour index after indexing for sub-linear search on large codebases.
+- **`file_stats` table** — O(files) change detection table. Incremental
+  re-indexing now reads one row per file instead of scanning all chunks.
+- **Auto device detection** — selects Metal (Apple Silicon), CUDA (NVIDIA),
+  or CPU automatically for the torch backend.
+
+**Configuration**
+- `VECGREP_BACKEND` env var — `onnx` (default, fast) or `torch` (any HF model).
+- `VECGREP_MODEL` env var — override the default HuggingFace model ID.
+- Default model switched to [`isuruwijesiri/all-MiniLM-L6-v2-code-search-512`](https://huggingface.co/isuruwijesiri/all-MiniLM-L6-v2-code-search-512),
+  fine-tuned for semantic code search (384-dim, ~80MB one-time download).
+
+**MCP tools**
+- `stop_watching` — new tool to explicitly stop watching a codebase path.
+- Watch state persisted to `~/.vecgrep/watched.json` and restored on restart.
+- Background startup sync via daemon thread — server starts immediately.
+
+**Developer experience**
+- `.githooks/pre-commit` lint check — run `git config core.hooksPath .githooks`
+  once per clone to enable.
+
+### Fixed
+
+- `build_index()` passed `"vector"` as positional arg to `create_index()`,
+  mapping to `metric` instead of `vector_column_name`.
+- `list_tables()` returned `ListTablesResponse` instead of a plain list,
+  causing `set()` to fail with an unhashable type error.
+
+### Performance summary
+
+| Metric | 1.0.0 | 1.5.0 |
+|---|---|---|
+| MCP server startup | ~6.6s | ~1.25s |
+| Model load (first embed) | ~2–3s | ~100ms |
+| Change detection | O(chunks) SHA-256 | O(files) mtime+size |
+
+---
+
 ## [1.0.0] — 2026-02-22
 
 First stable release.


### PR DESCRIPTION
# Pull Request

## Type of Change
- [x] 🔧 Chore (build process, CI/CD, dependency updates)
- [x] 📖 Documentation update

## Description

Adds the `1.5.0` changelog entry to `CHANGELOG.md` ahead of the GitHub release tag.

## Related Issues / PRs

Closes all work merged since `1.0.0`:
- PR #24 — feat/code-search-optimizations (LanceDB, ANN index, file_stats, fine-tuned model)
- PR #29 — perf/lazy-import-startup (fastembed ONNX backend, VECGREP_BACKEND/VECGREP_MODEL)
- PR #30 — chore/update-repo-urls (VecGrep org)
- PR #33 — chore/add-githooks (pre-commit lint check)

## Checklist
- [x] My code follows the project's style guidelines (`ruff` passes)
- [x] I have performed a self-review of my own code