### PR TITLE
chore: release 1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to VecGrep are documented here.
 
 ---
 
-## [Unreleased]
+## [1.8.0] — 2026-05-19
 
 ### Added
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vecgrep"
-version = "1.7.0"
+version = "1.8.0"
 description = "Cursor-style vector search MCP plugin for Claude Code"
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
## Release 1.8.0

### What's in this release

- `min_score` parameter on `search_code` (default `0.35`) — filters sub-threshold results before returning, reducing token noise
- `get_index_status` now surfaces the default min score threshold

### Checklist

- [x] Version bumped to `1.8.0` in `pyproject.toml`
- [x] `CHANGELOG.md` finalized with release date
- [x] All tests passing